### PR TITLE
Removed "trying" from rendering on page

### DIFF
--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -122,7 +122,6 @@ function pmpro_affiliates_wp_head()
 
 			//track the visit
 			if(empty($_COOKIE['pmpro_affiliate'])) {
-				echo "trying";
 				$wpdb->query("UPDATE $wpdb->pmpro_affiliates SET visits = visits + 1 WHERE code = '" . esc_sql($pmpro_affiliate_code) . "' LIMIT 1");
 			}
 


### PR DESCRIPTION
Removed an `echo "trying"` since the line caused the word "trying" to actually be rendered on the site when a user visits the site for the first time using an affiliate link.