### PR TITLE
More thorough post content checking

### DIFF
--- a/pages/report.php
+++ b/pages/report.php
@@ -7,7 +7,8 @@
 		if(!is_admin())
 		{
 			global $post, $current_user;
-			if(!empty($post->post_content) && strpos($post->post_content, "[pmpro_affiliates_report]") !== false)
+			if((!empty($post->post_content) && strpos($post->post_content, "[pmpro_affiliates_report]") !== false)
+				|| (!empty($post->post_content_filtered) && strpos($post->post_content_filtered, "[pmpro_affiliates_report]") !== false))
 			{
 				/*
 					Preheader operations here.


### PR DESCRIPTION
Added checks for the `[post_content_filtered]` shortcode in the `post_content_filtered` field in order to add compatibility for certain Wordpress Themes, such as Layers. This addition is necessary in order for the affiliates page to work with Layers pages because layers pages have nothing in the `post_content` field and instead have everything in the `post_content_filtered` field.