### PR TITLE
add filter for cookiedays

### DIFF
--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -80,7 +80,16 @@
 		$name = "";
 		$affiliateuser = "";
 		$trackingcode = "";
-		$cookiedays = intval( apply_filters( 'pmproaf_default_cookie_duration', 30, $user_id, $pmpro_level ) );
+		$cookiedays = 30;
+		/**
+		 *  Filter to adjust the number of days a cookie is valid for.
+		 *
+		 * @param mixed $cookiedays - number of days cookie should last, accepts numerical string or integer
+		 * @param integer $user_id - User ID
+		 * @param object $pmpro_level - membership level object
+		 */
+		$cookiedays = apply_filters( 'pmproaf_default_cookie_duration', $cookiedays, $user_id, $pmpro_level );
+		$cookiedays = intval( $cookiedays );
 		$enabled = true;
 	}
 

--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -87,6 +87,7 @@
 		 * @param mixed $cookiedays - number of days cookie should last, accepts numerical string or integer
 		 * @param integer $user_id - User ID
 		 * @param object $pmpro_level - membership level object
+		 * @return mixed  number of days cookie should last
 		 */
 		$cookiedays = apply_filters( 'pmproaf_default_cookie_duration', $cookiedays, $user_id, $pmpro_level );
 		$cookiedays = intval( $cookiedays );

--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -80,7 +80,7 @@
 		$name = "";
 		$affiliateuser = "";
 		$trackingcode = "";
-		$cookiedays = "30";
+		$cookiedays = intval( apply_filters( 'pmproaf_default_cookie_duration', 30, $user_id, $pmpro_level ) );
 		$enabled = true;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We have a [filter](https://github.com/strangerstudios/pmpro-affiliates/blob/769a00e71a4a8e2b2520fefb5e63419f096333a4/pmpro-affiliates.php#L291) `pmproaf_default_cookie_duration` that allows setting a custom cookie length duration for when an affiliate is code is given to a new member during level checkout. This filter does not affect the default cookie length when an affiliate code is manually assigned to a user via GUI in the administrative area.

This PR adds the filter as the value for the `$cookiedays` variable on the `/adminpages/affiliate.php` page, allowing to sync the default cookie length value set by the filter across the application.

### How to test the changes in this Pull Request:

1. Create [function that hooks into filter](https://gist.github.com/ipokkel/d15e1c62988dbcc34a1bb4f1f7b95a47) and returns a custom numeric value for days.
2. Navigate to Memberships > Affiliates > Manage Affiliates and "Add New Affiliate.
3. The "Cookie Length: ### In days should display the new default cookie length numeric value set

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Enhancement: Add `pmproaf_default_cookie_duration` filter to set default cookie length when adding an affiliate code manually.
