### PR TITLE
Fix/autoset code

### DIFF
--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -405,7 +405,17 @@ function pmpro_affiliates_yesorno($var)
 */
 function pmpro_affiliates_set_discount_code()
 {
-	global $wpdb;
+	global $wpdb, $pmpro_level;
+
+	// Is PMPro active?
+	if ( ! function_exists( 'pmpro_is_checkout' ) ) {
+		return;
+	}
+	
+	// Make sure we're on the checkout page.
+	if ( ! pmpro_is_checkout() ) {
+		return;
+	}
 
 	//checkout page
 	if(!isset($_REQUEST['discount_code']) && (!empty($_COOKIE['pmpro_affiliate']) || !empty($_REQUEST['pa'])))
@@ -420,7 +430,14 @@ function pmpro_affiliates_set_discount_code()
 		if(!empty($exists))
 		{
 			//check that the code is applicable for this level
-			$codecheck = pmpro_checkDiscountCode($affiliate_code, $_REQUEST['level']);
+			if( !empty( $pmpro_level ) ) {
+				$level_id = $pmpro_level->id;
+			} elseif ( !empty( $_REQUEST['level'] ) ) {
+				$level_id = intval( $_REQUEST['level'] );
+			} else {
+				$level_id = null;
+			}
+			$codecheck = pmpro_checkDiscountCode($affiliate_code, $level_id);
 			if($codecheck)
 				$_REQUEST['discount_code'] = $affiliate_code;
 		}

--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -438,6 +438,9 @@ function pmpro_affiliates_set_discount_code() {
 			$codecheck = pmpro_checkDiscountCode( $affiliate_code, $level_id );
 			if( $codecheck ) {
 				$_REQUEST['discount_code'] = $affiliate_code;
+				
+				//prevent caching of this page load
+				add_action( 'send_headers', 'nocache_headers' );
 			}
 		}
 	} elseif( ! empty( $_REQUEST['discount_code'] ) && empty( $_REQUEST['pa'] ) && empty( $_COOKIE['pmpro_affiliate'] ) ) {
@@ -449,6 +452,9 @@ function pmpro_affiliates_set_discount_code() {
 
 			//set the cookie to the discount code
 			$_COOKIE['pmpro_affiliate'] = $_REQUEST['discount_code'];
+			
+			//prevent caching of this page load
+			add_action( 'send_headers', 'nocache_headers' );
 		}
 	}
 }

--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -403,8 +403,7 @@ function pmpro_affiliates_yesorno($var)
 
 	If an affiliate code was passed or is already saved in a cookie and a discount code is used, the previous affiliate takes precedence.
 */
-function pmpro_affiliates_set_discount_code()
-{
+function pmpro_affiliates_set_discount_code() {
 	global $wpdb, $pmpro_level;
 
 	// Is PMPro active?
@@ -418,36 +417,33 @@ function pmpro_affiliates_set_discount_code()
 	}
 
 	//checkout page
-	if(!isset($_REQUEST['discount_code']) && (!empty($_COOKIE['pmpro_affiliate']) || !empty($_REQUEST['pa'])))
-	{
-		if(!empty($_COOKIE['pmpro_affiliate']))
+	if(  !isset( $_REQUEST['discount_code'] ) && ( ! empty( $_COOKIE['pmpro_affiliate'] ) || ! empty( $_REQUEST['pa'] ) ) ) {
+		if( ! empty( $_COOKIE['pmpro_affiliate'] ) ) {
 			$affiliate_code = $_COOKIE['pmpro_affiliate'];
-		else
+		} else {
 			$affiliate_code = $_REQUEST['pa'];
+		}
 
 		//set the discount code if there is an affiliate cookie
-		$exists = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql($affiliate_code) . "' LIMIT 1");
-		if(!empty($exists))
-		{
+		$exists = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $affiliate_code ) . "' LIMIT 1" );
+		if( ! empty( $exists ) ) {
 			//check that the code is applicable for this level
-			if( !empty( $pmpro_level ) ) {
+			if( ! empty( $pmpro_level ) ) {
 				$level_id = $pmpro_level->id;
-			} elseif ( !empty( $_REQUEST['level'] ) ) {
+			} elseif ( ! empty( $_REQUEST['level'] ) ) {
 				$level_id = intval( $_REQUEST['level'] );
 			} else {
 				$level_id = null;
 			}
-			$codecheck = pmpro_checkDiscountCode($affiliate_code, $level_id);
-			if($codecheck)
+			$codecheck = pmpro_checkDiscountCode( $affiliate_code, $level_id );
+			if( $codecheck ) {
 				$_REQUEST['discount_code'] = $affiliate_code;
+			}
 		}
-	}
-	elseif(!empty($_REQUEST['discount_code']) && empty($_REQUEST['pa']) && empty($_COOKIE['pmpro_affiliate']))
-	{
+	} elseif( ! empty( $_REQUEST['discount_code'] ) && empty( $_REQUEST['pa'] ) && empty( $_COOKIE['pmpro_affiliate'] ) ) {
 		//set the affiliate id to the discount code
-		$exists = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_affiliates WHERE code = '" . esc_sql($_REQUEST['discount_code']) . "' LIMIT 1");
-		if(!empty($exists))
-		{
+		$exists = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_affiliates WHERE code = '" . esc_sql( $_REQUEST['discount_code'] ) . "' LIMIT 1" );
+		if( ! empty( $exists ) ) {
 			//set the affiliate id passed in to the discount code
 			$_REQUEST['pa'] = $_REQUEST['discount_code'];
 
@@ -456,7 +452,7 @@ function pmpro_affiliates_set_discount_code()
 		}
 	}
 }
-add_action("init", "pmpro_affiliates_set_discount_code", 30);
+add_action( 'init', 'pmpro_affiliates_set_discount_code', 30 );
 
 //service for csv export
 function pmpro_wp_ajax_affiliates_report_csv()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This function tries to sync discount codes and affiliates by setting one or the other when you visit a page.

We're now only running this code on the checkout page since this is the only page we really care to sync things. The affiliate code is saved into a cookie so still available on the checkout page.

We try to get the level id to check from the pmpro_level global if available. This prevents a warning and also is smarter about how PMPro checkout pages can work.

Finally, there is code now to prevent the caching of the page when these $_REQUEST vars are set. This will prevent follow up visits from getting the cached affiliate/discount code "for free" just because the previous user who the cache was generated for had that affiliate or code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
