### PR TITLE
Fixes an undefined variable when using autocomplete

### DIFF
--- a/includes/js/admin.js
+++ b/includes/js/admin.js
@@ -40,7 +40,7 @@ jQuery(document).ready(function () {
                     {
                         search: term.term,
                         action: 'pmpro_affiliates_autocomplete_user_search',
-                        search_nonce: pmpro_affiliates_admin.pmpro_affiliates_search_nonce
+                        search_nonce: pmpro_affiliates_admin.search_nonce
                     },
                     function (res) {
                         suggest(res.data);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reference to the nonce that is used in the Autocomplete request was undefined and has been fixed

### How to test the changes in this Pull Request:

1. Navigate to Affiliates
2. Add New affiliate and fill out the username (let autocomplete run)
3. Add the user
4. Check the error log, no errors should come up

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed an undefined variable that was sent during an autocomplete ajax request
