### PR TITLE
Block Functions Renamed

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -4,7 +4,7 @@
  * 
  * @since 1.2
  */
-function pmpro_courses_register_block_type() {
+function pmpro_affiliates_register_block_type() {
 	register_block_type( 'pmpro-affiliates/pmpro-affiliates-report', 
 		array(
         	'editor_script'   => 'pmpro_affiliates_block_report',
@@ -58,14 +58,14 @@ function pmpro_courses_register_block_type() {
 		)
 	);
 }
-add_action( 'init', 'pmpro_courses_register_block_type' );
+add_action( 'init', 'pmpro_affiliates_register_block_type' );
 
 /**
  * Enqueue the Block Scripts for both blocks.
  *
  * @since 1.2
  */
-function pmpro_courses_block_scripts() {
+function pmpro_affiliates_block_scripts() {
 	wp_enqueue_script(
 		'pmpro_affiliates_block_report',
 		plugins_url( 'blocks/build/pmpro_affiliates_report/index.js', __DIR__ ),
@@ -73,4 +73,4 @@ function pmpro_courses_block_scripts() {
 	);
 
 }
-add_action( 'enqueue_block_editor_assets', 'pmpro_courses_block_scripts' );
+add_action( 'enqueue_block_editor_assets', 'pmpro_affiliates_block_scripts' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Functions used in the blocks.php file referenced 'courses' resulting in a fatal error occurring when the Courses Add On is active

### How to test the changes in this Pull Request:

1. Activate the Affiliates Add On
2. Activate the Courses Add On
3. Both should run concurrently without any errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Block functions renamed to suit affiliates add on
