### PR TITLE
Title tags added to Paid and Reset Buttons

### DIFF
--- a/adminpages/report.php
+++ b/adminpages/report.php
@@ -104,10 +104,10 @@
 						if ( $affiliate_paid == '1' ) {
 							$nonce = wp_create_nonce( 'pmpro_affiliates_reset_paid_status' );
 							$affiliate_paid = esc_html__( 'Paid', 'pmpro-affiliates' );
-							$affiliate_paid .= ' [<a class="pmpro_affiliates_reset_paid_status" href="javascript:void(0)" order_id="' . esc_attr( $order->order_id ) . '" _wpnonce="' . esc_attr( $nonce ) . '" >x</a>]'  ;
+							$affiliate_paid .= ' [<a class="pmpro_affiliates_reset_paid_status" href="javascript:void(0)" order_id="' . esc_attr( $order->order_id ) . '" _wpnonce="' . esc_attr( $nonce ) . '" title="' . esc_html__( 'Reset Payment Status', 'pmpro-affiliates' ) . '" >x</a>]'  ;
 						} else {
 							$nonce = wp_create_nonce( 'pmpro_affiliates_mark_as_paid' );
-							$affiliate_paid = '<a class="pmpro_affiliates_mark_as_paid" href="javascript:void(0)" order_id="' . esc_attr( $order->order_id ) . '" _wpnonce="' . esc_attr( $nonce ) . '" >' . esc_html__( 'Mark as Paid', 'pmpro-affiliates' ) . '</a>';
+							$affiliate_paid = '<a class="pmpro_affiliates_mark_as_paid" href="javascript:void(0)" order_id="' . esc_attr( $order->order_id ) . '" _wpnonce="' . esc_attr( $nonce ) . '" title="' . esc_html__( 'Mark as Paid', 'pmpro-affiliates' ) . '" >' . esc_html__( 'Mark as Paid', 'pmpro-affiliates' ) . '</a>';
 						}
 						?>
 						<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

HTML titles added to the Mark as Paid and Reset Payment Status links for accessibility

### How to test the changes in this Pull Request:

1. Navigate to Affiliates
2. Click on a report
3. Ensure that there are affiliate earnings
4. Hover over Mark as Paid - title will show
5. Refresh the page and hover over the X - title will show

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

