### PR TITLE
Adjusting the frontend affiliate report screen for responsive

### DIFF
--- a/includes/css/frontend.css
+++ b/includes/css/frontend.css
@@ -1,66 +1,121 @@
 .pmpro_affiliates-table-container {
-    display: flex;
-    flex-flow: column wrap;
-    background-color: white;
-    width: 100%;
-    margin: 30px auto;
-    border: 1px solid #D6D6D6;
+	background-color: white;
+	width: 100%;
+	margin: 30px auto;
+	border: 1px solid #D6D6D6;
 }
-
-.pmpro_affiliates-table-container .table-row {
-    display: flex;
-    flex-flow: row wrap;
-    width: 100%;
-    border-bottom: 1px solid #D6D6D6;
-}
-
-.pmpro_affiliates-table-container .table-row-heading {
-    background-color: #EFEFEF;
-    color: #3e3e3e;
-    font-weight: bold;
-}
-
 .pmpro_affiliates-table-container .row-item {
-    display: flex;
-    flex: 1;
-    font-size: 14px;
-    padding: 12px;
-    justify-content: center;
-    align-items: center;
-    overflow: scroll;
+	font-size: 14px;
+	overflow: scroll;
 }
-
+.pmpro_affiliates-table-container .table-row {
+	width: 100%;
+	border-bottom: 1px solid #D6D6D6;
+}
+.pmpro_affiliates-table-container .table-row-heading {
+	background-color: #EFEFEF;
+	color: #3E3E3E;
+	font-weight: bold;
+}
+.pmpro_affiliates-table-container .row-item {
+	font-size: 14px;
+	overflow: scroll;
+}
 .pmpro_affiliates-table-container .table-row:last-child {
-    border-bottom: 0;
+	border-bottom: 0;
 }
 
 /** Commissions Table **/
+.pmpro_affiliates-table-container.pmpro_affiliates-commissions .table-row-heading{
+	text-align: right;
+}
 .pmpro_affiliates-commissions .table-row-body .row-item {
-    font-size: 20px;
-    font-weight: 700;
+	font-size: 20px;
+	font-weight: 700;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-commissions {
+	display: flex;
+	flex-direction: row;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-commissions .row-item {
+	padding: 12px;
 }
 
 /** Orders Table **/
-.pmpro_affiliates-orders .row-item {
-    justify-content: initial;
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .table-row-heading {
+	display: none;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .table-row-body {
+	padding: 12px;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .table-row-body:nth-child(odd) {
+	background-color: #F8F8F8;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item {
+	justify-content: initial;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item:first-child {
+	font-weight: bold;
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item:after {
+	content: ", ";
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item:last-child:after {
+	content: "";
+}
+.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item {
+	display: inline;
+}
+
+@media only screen and (min-width: 769px) {
+	.pmpro_affiliates-table-container {
+		flex-flow: column wrap;
+	}
+	.pmpro_affiliates-table-container .table-row {
+		display: flex;
+		flex-flow: row wrap;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-commissions .table-row-heading {
+		text-align: center;
+	}
+	.pmpro_affiliates-table-container .row-item {
+		display: flex;
+		flex: 1;
+		align-items: center;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-commissions .row-item {
+		justify-content: center;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-orders .table-row-heading {
+		display: flex;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-orders .table-row-body {
+		padding: 0;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item {
+		padding: 12px;
+	}
+	.pmpro_affiliates-table-container.pmpro_affiliates-orders .row-item:after {
+		content: "";
+	}
 }
 
 /** Create Links **/
 .pmpro_affiliates-links {
-    border: 1px solid #D6D6D6;
-    margin: 30px auto;
-    padding: 30px;
+	border: 1px solid #D6D6D6;
+	margin: 30px auto;
+	padding: 30px;
 }
 .pmpro_affiliates-links h2 {
-    margin: 0;
-    padding: 0;
+	margin: 0;
+	padding: 0;
 }
 .pmpro_affiliates-links p {
-    margin: 30px 0 0 0;
-    padding: 0;
+	margin: 30px 0 0 0;
+	padding: 0;
 }
 
 /** Report Navigation **/
 .pmpro_affiliates-actions_nav {
-    margin-bottom: 60px;
+	margin-bottom: 60px;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adjusted the appearance of the report for smaller screens. We now collapse the commissions section into rows and show the affiliate orders list in a collapsed view as well.

<img width="569" alt="Screenshot 2023-01-06 at 6 55 06 AM" src="https://user-images.githubusercontent.com/5312875/211008986-775ebced-b99c-4477-b4e7-695ae52837f6.png">
Mobile view / responsive view for smaller screens 

<img width="883" alt="Screenshot 2023-01-06 at 6 55 36 AM" src="https://user-images.githubusercontent.com/5312875/211008978-3081f626-2edf-417a-85d0-b580699d7491.png">
Larger screens expanded view
