### PR TITLE
No longer setting discount code in $_REQUEST

### DIFF
--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -399,7 +399,7 @@ function pmpro_affiliates_yesorno( $var ) {
 	Legacy function for PMPro < 3.0.
 */
 function pmpro_affiliates_set_discount_code() {
-	global $wpdb;
+	global $wpdb, $pmpro_level;
 
 	// Is PMPro active?
 	if ( ! function_exists( 'pmpro_is_checkout' ) ) {


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops setting the discount code with the `$_REQUEST` variable (since we are prefixing the `discount_code` parameter in 3.0) and instead uses the new `pmpro_default_discount_code` filter.