### PR TITLE
Adds a filter to determine commission on subtotal or total

### DIFF
--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -115,14 +115,6 @@
 		$enabled = true;
 	}
 
-	$filter_on = "total";
-
-	$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
-
-	if ( $calculate_subtotal ) {
-		$filter_on = "subtotal";
-	}
-
 	if($edit && $save)
 	{
 		//updating or new?
@@ -450,7 +442,7 @@
 							</td>
 							<td>
 								<?php
-									$norders = $wpdb->get_var("SELECT COUNT(".esc_sql( $filter_on ).") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
+									$norders = $wpdb->get_var("SELECT COUNT(" . esc_sql( pmpro_affiliates_get_commission_calculation_source() ) . ") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
 									if(empty($affiliate->visits))
 										echo "0%";
 									else
@@ -459,7 +451,7 @@
 							</td>
 							<?php
 							// Calculate earnings so we can show commission earned and total earnings.
-								$earnings = $wpdb->get_var("SELECT SUM(".esc_sql( $filter_on ).") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
+								$earnings = $wpdb->get_var("SELECT SUM(" . esc_sql( pmpro_affiliates_get_commission_calculation_source() ) . ") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
 								
 							?>
 							

--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -115,6 +115,14 @@
 		$enabled = true;
 	}
 
+	$filter_on = "total";
+
+	$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
+
+	if ( $calculate_subtotal ) {
+		$filter_on = "subtotal";
+	}
+
 	if($edit && $save)
 	{
 		//updating or new?
@@ -442,7 +450,7 @@
 							</td>
 							<td>
 								<?php
-									$norders = $wpdb->get_var("SELECT COUNT(total) FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
+									$norders = $wpdb->get_var("SELECT COUNT(".esc_sql( $filter_on ).") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
 									if(empty($affiliate->visits))
 										echo "0%";
 									else
@@ -451,7 +459,7 @@
 							</td>
 							<?php
 							// Calculate earnings so we can show commission earned and total earnings.
-								$earnings = $wpdb->get_var("SELECT SUM(total) FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
+								$earnings = $wpdb->get_var("SELECT SUM(".esc_sql( $filter_on ).") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
 								
 							?>
 							

--- a/adminpages/report-csv.php
+++ b/adminpages/report-csv.php
@@ -28,15 +28,7 @@ if ( ! function_exists( 'current_user_can' )
 	die( __( 'You do not have permissions to perform this action.', 'pmpro-affiliates' ) );
 }
 
-$filter_on = "o.total";
-
-$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
-
-if ( $calculate_subtotal ) {
-    $filter_on = "o.subtotal";
-}
-
-	$sql_query = "SELECT o.id as order_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.user_login, o.user_id, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on ).", o.status, om.meta_value as affiliate_paid
+	$sql_query = "SELECT o.id as order_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.user_login, o.user_id, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, " . esc_sql( 'o.' . pmpro_affiliates_get_commission_calculation_source() ) . " as total, o.status, om.meta_value as affiliate_paid
 	FROM $wpdb->pmpro_membership_orders o
 	LEFT JOIN $wpdb->pmpro_affiliates a 
 	ON o.affiliate_id = a.id 
@@ -88,8 +80,8 @@ if ( $report !== 'all' ) {
 				pmpro_enclose( $order->name ),
 				pmpro_enclose( date_i18n( 'Y-m-d', $order->timestamp ) ),
 				pmpro_enclose( $order->commissionrate * 100 ) . '%',
-                ( $calculate_subtotal ) ? pmpro_enclose( number_format( $order->subtotal * $order->commissionrate, 2 ) ) : pmpro_enclose( number_format( $order->total * $order->commissionrate, 2 ) ),
-                ( $calculate_subtotal ) ? pmpro_enclose( $order->subtotal ) : pmpro_enclose( $order->total ),
+				pmpro_enclose( number_format( $order->total * $order->commissionrate, 2 ) ),
+				pmpro_enclose( $order->total ),
 			);
 
 			$pmpro_affiliate_report_data = apply_filters( 'pmpro_affiliate_list_csv_extra_column_data', $pmpro_affiliate_report_data, $order, $level );

--- a/adminpages/report.php
+++ b/adminpages/report.php
@@ -61,17 +61,8 @@
 ?>
 
 <?php
-
-	$filter_on = "o.total";
-
-	$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
-
-	if ( $calculate_subtotal ) {
-		$filter_on = "o.subtotal";
-	}
-
 	$sqlQuery = 
-	"SELECT o.id as order_id, o.code as order_code, a.id as affiliate_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.ID as user_id, u.user_login, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on).", o.status, om.meta_value as affiliate_paid
+	"SELECT o.id as order_id, o.code as order_code, a.id as affiliate_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.ID as user_id, u.user_login, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, " . esc_sql( 'o.' . pmpro_affiliates_get_commission_calculation_source() ) . " as total, o.status, om.meta_value as affiliate_paid
 	FROM $wpdb->pmpro_membership_orders o 
 	LEFT JOIN $wpdb->pmpro_affiliates a 
 	ON o.affiliate_id = a.id 
@@ -112,13 +103,6 @@
 				<?php
 					global $pmpro_currency_symbol;
 					foreach ( $affiliate_orders as $order ) {
-
-						if( $calculate_subtotal ) {
-							$order_total = $order->subtotal;
-						} else {
-							$order_total = $order->total;
-						}
-
 						$level = pmpro_getLevel( $order->membership_id ); 
 						// Get the affiliate paid status and generate a mark as paid link if not paid. Add nonce.
 						$affiliate_paid = $order->affiliate_paid;
@@ -169,8 +153,8 @@
 							</td>
 							<td><?php echo date_i18n( get_option( 'date_format' ), $order->timestamp );?></td>
 							<td><?php echo esc_html( $order->commissionrate * 100 );?>%</td>
-							<td><?php echo pmpro_formatPrice( $order_total * $order->commissionrate ); ?></td>
-							<td><?php echo pmpro_formatPrice( $order_total ); ?></td>
+							<td><?php echo pmpro_formatPrice( $order->total * $order->commissionrate ); ?></td>
+							<td><?php echo pmpro_formatPrice( $order->total ); ?></td>
 							<td><?php echo '<span class="pmpro_affiliate_paid_status" id="order_' . esc_attr( $order->order_id ) . '">' . $affiliate_paid . '</span>'; // We escape the $affiliate_paid before outputting further up.?></td>
 							<?php do_action( "pmpro_affiliate_report_extra_cols_body", $order ); ?>
 						</tr>

--- a/adminpages/report.php
+++ b/adminpages/report.php
@@ -61,8 +61,17 @@
 ?>
 
 <?php
+
+	$filter_on = "o.total";
+
+	$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
+
+	if ( $calculate_subtotal ) {
+		$filter_on = "o.subtotal";
+	}
+
 	$sqlQuery = 
-	"SELECT o.id as order_id, o.code as order_code, a.id as affiliate_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.ID as user_id, u.user_login, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, o.total, o.status, om.meta_value as affiliate_paid
+	"SELECT o.id as order_id, o.code as order_code, a.id as affiliate_id, a.code, a.commissionrate, o.affiliate_subid as subid, a.name, u.ID as user_id, u.user_login, o.membership_id, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on).", o.status, om.meta_value as affiliate_paid
 	FROM $wpdb->pmpro_membership_orders o 
 	LEFT JOIN $wpdb->pmpro_affiliates a 
 	ON o.affiliate_id = a.id 
@@ -103,6 +112,13 @@
 				<?php
 					global $pmpro_currency_symbol;
 					foreach ( $affiliate_orders as $order ) {
+
+						if( $calculate_subtotal ) {
+							$order_total = $order->subtotal;
+						} else {
+							$order_total = $order->total;
+						}
+
 						$level = pmpro_getLevel( $order->membership_id ); 
 						// Get the affiliate paid status and generate a mark as paid link if not paid. Add nonce.
 						$affiliate_paid = $order->affiliate_paid;
@@ -153,8 +169,8 @@
 							</td>
 							<td><?php echo date_i18n( get_option( 'date_format' ), $order->timestamp );?></td>
 							<td><?php echo esc_html( $order->commissionrate * 100 );?>%</td>
-							<td><?php echo pmpro_formatPrice( $order->total * $order->commissionrate ); ?></td>
-							<td><?php echo pmpro_formatPrice( $order->total ); ?></td>
+							<td><?php echo pmpro_formatPrice( $order_total * $order->commissionrate ); ?></td>
+							<td><?php echo pmpro_formatPrice( $order_total ); ?></td>
 							<td><?php echo '<span class="pmpro_affiliate_paid_status" id="order_' . esc_attr( $order->order_id ) . '">' . $affiliate_paid . '</span>'; // We escape the $affiliate_paid before outputting further up.?></td>
 							<?php do_action( "pmpro_affiliate_report_extra_cols_body", $order ); ?>
 						</tr>

--- a/pages/report.php
+++ b/pages/report.php
@@ -132,7 +132,17 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 		<?php } ?>
 		<h2><?php echo ucwords( $pmpro_affiliates_singular_name ); ?> <?php echo esc_html__( 'Report for Code:', 'pmpro-affiliates' ) . ' ' . esc_html( $affiliate->code ); ?></h2>
 		<?php
-			$sqlQuery = "SELECT a.code, o.affiliate_subid as subid, a.name, u.user_login, UNIX_TIMESTAMP(o.timestamp) as timestamp, o.total, o.membership_id, o.status FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_affiliates a ON o.affiliate_id = a.id LEFT JOIN $wpdb->users u ON o.user_id = u.ID WHERE o.affiliate_id <> '' AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review') ";
+
+		$filter_on = "o.total";
+
+		$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
+
+		if ( $calculate_subtotal ) {
+			$filter_on = "o.subtotal";
+		}
+		
+		$sqlQuery = "SELECT a.code, o.affiliate_subid as subid, a.name, u.user_login, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on ).", o.membership_id, o.status FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_affiliates a ON o.affiliate_id = a.id LEFT JOIN $wpdb->users u ON o.user_id = u.ID WHERE o.affiliate_id <> '' AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review') ";
+		var_dump($sqlQuery);
 		if ( $report != 'all' ) {
 			$sqlQuery .= " AND a.id = '" . esc_sql( $report ) . "' ";
 		}
@@ -232,7 +242,7 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 							<div class="row-item"><?php echo pmpro_formatPrice( $order->total * $affiliate->commissionrate ); ?></div>
 						<?php } ?>
 						<?php if ( in_array( 'total', $fields ) ) { ?>
-								<div class="row-item"><?php echo pmpro_formatPrice( $order->total ); ?></div>
+								<div class="row-item"><?php echo ( $calculate_subtotal ) ? pmpro_formatPrice( $order->subtotal ) : pmpro_formatPrice( $order->total ); ?></div>
 							<?php } ?>
 						</div>
 						<?php

--- a/pages/report.php
+++ b/pages/report.php
@@ -239,7 +239,7 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 							</div>
 						<?php } ?>
 						<?php if ( in_array( 'show_commission', $fields ) ) { ?>
-							<div class="row-item"><?php echo pmpro_formatPrice( $order->total * $affiliate->commissionrate ); ?></div>
+							<div class="row-item"><?php echo ( $calculate_subtotal ) ? pmpro_formatPrice($order->subtotal * $affiliate->commissionrate) : pmpro_formatPrice($order->total * $affiliate->commissionrate); ?></div>
 						<?php } ?>
 						<?php if ( in_array( 'total', $fields ) ) { ?>
 								<div class="row-item"><?php echo ( $calculate_subtotal ) ? pmpro_formatPrice( $order->subtotal ) : pmpro_formatPrice( $order->total ); ?></div>

--- a/pages/report.php
+++ b/pages/report.php
@@ -132,17 +132,7 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 		<?php } ?>
 		<h2><?php echo ucwords( $pmpro_affiliates_singular_name ); ?> <?php echo esc_html__( 'Report for Code:', 'pmpro-affiliates' ) . ' ' . esc_html( $affiliate->code ); ?></h2>
 		<?php
-
-		$filter_on = "o.total";
-
-		$calculate_subtotal = apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false );
-
-		if ( $calculate_subtotal ) {
-			$filter_on = "o.subtotal";
-		}
-		
-		$sqlQuery = "SELECT a.code, o.affiliate_subid as subid, a.name, u.user_login, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on ).", o.membership_id, o.status FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_affiliates a ON o.affiliate_id = a.id LEFT JOIN $wpdb->users u ON o.user_id = u.ID WHERE o.affiliate_id <> '' AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review') ";
-
+		$sqlQuery = "SELECT a.code, o.affiliate_subid as subid, a.name, u.user_login, UNIX_TIMESTAMP(o.timestamp) as timestamp, " . esc_sql( 'o.' . pmpro_affiliates_get_commission_calculation_source() ) . " as total, o.membership_id, o.status FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_affiliates a ON o.affiliate_id = a.id LEFT JOIN $wpdb->users u ON o.user_id = u.ID WHERE o.affiliate_id <> '' AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review') ";
 		if ( $report != 'all' ) {
 			$sqlQuery .= " AND a.id = '" . esc_sql( $report ) . "' ";
 		}
@@ -239,10 +229,10 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 							</div>
 						<?php } ?>
 						<?php if ( in_array( 'show_commission', $fields ) ) { ?>
-							<div class="row-item"><?php echo ( $calculate_subtotal ) ? pmpro_formatPrice($order->subtotal * $affiliate->commissionrate) : pmpro_formatPrice($order->total * $affiliate->commissionrate); ?></div>
+							<div class="row-item"><?php echo pmpro_formatPrice( $order->total * $affiliate->commissionrate ); ?></div>
 						<?php } ?>
 						<?php if ( in_array( 'total', $fields ) ) { ?>
-								<div class="row-item"><?php echo ( $calculate_subtotal ) ? pmpro_formatPrice( $order->subtotal ) : pmpro_formatPrice( $order->total ); ?></div>
+								<div class="row-item"><?php echo pmpro_formatPrice( $order->total ); ?></div>
 							<?php } ?>
 						</div>
 						<?php

--- a/pages/report.php
+++ b/pages/report.php
@@ -142,7 +142,7 @@ function pmpro_affiliates_report_shortcode( $atts, $content = null, $code = '' )
 		}
 		
 		$sqlQuery = "SELECT a.code, o.affiliate_subid as subid, a.name, u.user_login, UNIX_TIMESTAMP(o.timestamp) as timestamp, ".esc_sql( $filter_on ).", o.membership_id, o.status FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_affiliates a ON o.affiliate_id = a.id LEFT JOIN $wpdb->users u ON o.user_id = u.ID WHERE o.affiliate_id <> '' AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review') ";
-		var_dump($sqlQuery);
+
 		if ( $report != 'all' ) {
 			$sqlQuery .= " AND a.id = '" . esc_sql( $report ) . "' ";
 		}

--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -744,13 +744,7 @@ function pmpro_affiliates_get_commissions( $affiliate_code, $state = 'paid' ) {
 
 	$paid_commission = 0;
 
-	$filter_on = "o.total";
-
-	if ( apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false ) ) {
-		$filter_on = "o.subtotal";
-	}
-
-	$sql_query = "SELECT SUM(".esc_sql( $filter_on ).") as total, a.commissionrate
+	$sql_query = "SELECT SUM(" . esc_sql( 'o.' . pmpro_affiliates_get_commission_calculation_source() ) . ") as total, a.commissionrate
 				FROM $wpdb->pmpro_membership_orders o
 				LEFT JOIN $wpdb->pmpro_membership_ordermeta om 
 				ON o.id = om.pmpro_membership_order_id
@@ -824,6 +818,31 @@ function pmpro_affiliates_edit_user_profile( $user ) {
 
 }
 add_action( 'edit_user_profile', 'pmpro_affiliates_edit_user_profile' );
+
+/**
+ * Get the order column to use when calculating commisions.
+ * Should be either 'total' or 'subtotal'.
+ *
+ * @since TBD
+ *
+ * @return string The order column to use.
+ */
+function pmpro_affiliates_get_commission_calculation_source() {
+	/**
+	 * Filter to change the source of the commission calculation.
+	 * The valid values are 'total' or 'subtotal'.
+	 *
+	 * @param string $source The source of the commission calculation.
+	 */
+	$source = apply_filters( 'pmpro_affiliates_commission_calculation_source', 'total' );
+
+	// Validate the source.
+	if ( 'total' !== $source && 'subtotal' !== $source ) {
+		$source = 'total';
+	}
+
+	return $source;
+}
 
 /*
 Function to add links to the plugin action links

--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -744,7 +744,13 @@ function pmpro_affiliates_get_commissions( $affiliate_code, $state = 'paid' ) {
 
 	$paid_commission = 0;
 
-	$sql_query = "SELECT SUM(o.total) as total, a.commissionrate
+	$filter_on = "o.total";
+
+	if ( apply_filters( 'pmpro_affiliates_calculate_on_subtotal', false ) ) {
+		$filter_on = "o.subtotal";
+	}
+
+	$sql_query = "SELECT SUM(".esc_sql( $filter_on ).") as total, a.commissionrate
 				FROM $wpdb->pmpro_membership_orders o
 				LEFT JOIN $wpdb->pmpro_membership_ordermeta om 
 				ON o.id = om.pmpro_membership_order_id


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a filter to queries to determine if we should base commission off of the order subtotal (before tax) or total (after tax).

New filter is called `pmpro_affiliates_calculate_on_subtotal` and accepts a boolean value

### How to test the changes in this Pull Request:

1. Enable the filter `add_filter( 'pmpro_affiliates_calculate_on_subtotal', '__return_true' );`
2. Run a test checkout with tax in place or edit an order that has earned an affiliate commission - your subtotal and total should be different
3. Commission will be based on the subtotal when enabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
