### PR TITLE
Fixing non-affiliate orders showing in reports

### DIFF
--- a/adminpages/report-csv.php
+++ b/adminpages/report-csv.php
@@ -38,6 +38,8 @@ if ( ! function_exists( 'current_user_can' )
 	ON o.id = om.pmpro_membership_order_id
 	AND om.meta_key = 'pmpro_affiliate_paid'
 	WHERE o.affiliate_id <> ''
+	AND o.affiliate_id IS NOT NULL
+	AND o.affiliate_id <> 0
 	AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')";
 
 

--- a/adminpages/report.php
+++ b/adminpages/report.php
@@ -72,6 +72,8 @@
 	ON o.id = om.pmpro_membership_order_id
 	AND om.meta_key = 'pmpro_affiliate_paid'
 	WHERE o.affiliate_id <> ''
+	AND o.affiliate_id IS NOT NULL
+	AND o.affiliate_id <> 0
 	AND o.status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')";
 
 	if ( $report != "all" ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, all orders show in the Affiliate reports, even if they are not linked to an affiliate. This PR fixes that behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
