### PR TITLE
Fix affiliates not being credited for recurring orders

### DIFF
--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -203,7 +203,7 @@ function pmpro_affiliates_pmpro_added_order( $order, $savefirst = false ) {
 			FROM $wpdb->pmpro_membership_orders
 			WHERE user_id = '" . esc_sql( $order->user_id ) . "'
 			AND subscription_transaction_id = '" . esc_sql( $order->subscription_transaction_id ) . "'
-			AND affiliate_id <> ''
+			AND affiliate_id <> 0
 			ORDER BY id DESC LIMIT 1"
 		);
 		if ( ! empty( $lastorder ) ) {

--- a/pmpro-affiliates.php
+++ b/pmpro-affiliates.php
@@ -188,27 +188,20 @@ function pmpro_affiliates_wp_head() {
 }
 add_action( 'wp_head', 'pmpro_affiliates_wp_head' );
 
-// update order if cookie is present or the last order in this subscription used an affiliate
+// update order if cookie is present or the first order in this subscription used an affiliate
 function pmpro_affiliates_pmpro_added_order( $order, $savefirst = false ) {
-	 global $wpdb, $pmpro_affiliates_saved_order;
+	global $wpdb, $pmpro_affiliates_saved_order;
 	$pmpro_affiliates_saved_order = true;
 	$pmpro_affiliates_settings    = pmpro_affiliates_get_settings();
 	$pmpro_affiliates_recurring   = $pmpro_affiliates_settings['pmpro_affiliates_recurring'];
 
 	$user_id = $order->user_id;
-	// check for an order for this subscription with an affiliate id
+	// check for an affiliate id in the first order for this subscription
 	if ( ! empty( $order->subscription_transaction_id ) && ! empty( $pmpro_affiliates_recurring ) ) {
-		$lastorder = $wpdb->get_row(
-			"SELECT affiliate_id, affiliate_subid
-			FROM $wpdb->pmpro_membership_orders
-			WHERE user_id = '" . esc_sql( $order->user_id ) . "'
-			AND subscription_transaction_id = '" . esc_sql( $order->subscription_transaction_id ) . "'
-			AND affiliate_id <> 0
-			ORDER BY id DESC LIMIT 1"
-		);
-		if ( ! empty( $lastorder ) ) {
-			$affiliate_id    = $lastorder->affiliate_id;
-			$affiliate_subid = $lastorder->affiliate_subid;
+		$first_order = $order->get_original_subscription_order();
+		if ( ! empty( $first_order ) ) {
+			$affiliate_id    = $first_order->affiliate_id;
+			$affiliate_subid = $first_order->affiliate_subid;
 
 			$affiliate_code = $wpdb->get_var( "SELECT code FROM $wpdb->pmpro_affiliates WHERE id = '" . esc_sql( $affiliate_id ) . "' LIMIT 1" );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Checking for affiliate id in recurring subscription's first order using PMPro core methods.


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #56.

### How to test the changes in this Pull Request:

1. Apply changes.
2. Select _Yes - credit affiliate for initial payment and recurring orders._ in _Memberships > Affiliates > Settings_
3. Create affiliate code and set commission rate.
3. Visit the affiliate link and checkout for a recurring membership level.
4. Wait for recurring payment or advance clocks in Stripe (test) to trigger recurring subscription payment.
5. Check the affiliate report for the affiliate link used. Observe that commission is tracked for the recurring payment.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes an issue where affiliates were not being credited for recurring orders 
