### PR TITLE
Improve conversion rate tracking

### DIFF
--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -452,11 +452,12 @@
 							</td>
 							<td>
 								<?php
-									$norders = $wpdb->get_var("SELECT COUNT(" . esc_sql( pmpro_affiliates_get_commission_calculation_source() ) . ") FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
-									if(empty($affiliate->visits))
+									$norders = $wpdb->get_var("SELECT COUNT(DISTINCT user_id) FROM $wpdb->pmpro_membership_orders WHERE affiliate_id = '" . esc_sql($affiliate->id) . "' AND status NOT IN('pending', 'error', 'refunded', 'refund', 'token', 'review')");
+									if ( empty( $affiliate->visits ) ) {
 										echo "0%";
-									else
+									} else {
 										echo esc_html( round($norders / $affiliate->visits * 100, 2) . "%" );
+									}
 								?>
 							</td>
 							<?php


### PR DESCRIPTION
Counting just one order for each affiliate signup to fix an issue where conversion rates could go over 100%

Some WPCS changes

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Apply PR #59
2. Check out for recurring membership using affiliate code.
3. Add some orders for the recurring subscription
4. Observe that affiliate code's conversion % in _Memberships > Affiliates_ is over 100%
5. Apply PR
6. Check conversion %

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improved conversion rate tracking.
