### PR TITLE
Filter for default commission

### DIFF
--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -101,7 +101,7 @@
 		$affiliateuser = '';
 		$trackingcode = '';
 		$cookiedays = 30;
-		$commissionrate = 0;
+		$commissionrate = apply_filters( 'pmpro_affiliate_default_commission_rate', 5 ); //default to 5%
 		/**
 		 * Filter to adjust the number of days a cookie is valid for by default.
 		 * This can also be set and modified for each individual cookie.

--- a/adminpages/affiliates.php
+++ b/adminpages/affiliates.php
@@ -101,7 +101,17 @@
 		$affiliateuser = '';
 		$trackingcode = '';
 		$cookiedays = 30;
+		
+		/**
+		 * Filter the default placeholder for the commission rate when creating a new affiliate.
+		 * This is a percentage value, so 5% would be 5.
+		 * 
+		 * @since TBD
+		 * 
+		 * @param integer $rate The default commission rate.
+		 */
 		$commissionrate = apply_filters( 'pmpro_affiliate_default_commission_rate', 5 ); //default to 5%
+		
 		/**
 		 * Filter to adjust the number of days a cookie is valid for by default.
 		 * This can also be set and modified for each individual cookie.


### PR DESCRIPTION
* Added a new filter `pmpro_affiliate_default_commission_rate` to allow developers to tweak the default rate and adjusted it to 5% instead of 0%. This is totally adjustable and a placeholder value when creating a new affiliate.

Resolves: https://github.com/strangerstudios/pmpro-affiliates/issues/49

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-affiliates/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-affiliates/pulls/) for the same update/change?
