### PR TITLE
Fixing order link for PMPro v3.6+

### DIFF
--- a/adminpages/report.php
+++ b/adminpages/report.php
@@ -131,7 +131,7 @@
 							}
 							?>
 						</td>
-							<td><?php echo "<a href='" . esc_url( get_admin_url(NULL, '/admin.php?page=pmpro-orders&order=' . (int) $order->order_id ) . '&id=' . (int) $order->order_id ) . "'>" . esc_html( $order->order_code ) . "</a>"; ?></td>
+							<td><?php echo "<a href='" . esc_url( get_admin_url( NULL, '/admin.php?page=pmpro-orders&order=' . (int) $order->order_id . '&id=' . (int) $order->order_id ) ) . "'>" . esc_html( $order->order_code ) . "</a>"; ?></td>
 							<td><?php echo ! empty( $order->name ) ? esc_html( stripslashes($order->name) ) : '';?></td>
 							<td>
 								<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing broken link to view orders when running PMPro v3.6+

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
